### PR TITLE
CategoryRepository 생성

### DIFF
--- a/Projects/Memo/Sources/Category/CategoryBuilder.swift
+++ b/Projects/Memo/Sources/Category/CategoryBuilder.swift
@@ -8,9 +8,13 @@
 
 import RIBs
 
-protocol CategoryDependency: Dependency {}
+protocol CategoryDependency: Dependency {
+    var categoriesUseCase: CategoriesUseCase { get }
+}
 
-final class CategoryComponent: Component<CategoryDependency> {}
+final class CategoryComponent: Component<CategoryDependency> {
+    var categoriesUseCase: CategoriesUseCase { dependency.categoriesUseCase }
+}
 
 // MARK: - Builder
 
@@ -27,7 +31,10 @@ final class CategoryBuilder: Builder<CategoryDependency>, CategoryBuildable {
     func build(withListener listener: CategoryListener) -> CategoryRouting {
         let component = CategoryComponent(dependency: dependency)
         let viewController = CategoryViewController()
-        let interactor = CategoryInteractor(presenter: viewController)
+        let interactor = CategoryInteractor(
+            presenter: viewController,
+            categoriesUseCase: component.categoriesUseCase
+        )
         interactor.listener = listener
         return CategoryRouter(interactor: interactor, viewController: viewController)
     }

--- a/Projects/Memo/Sources/Category/CategoryInteractor.swift
+++ b/Projects/Memo/Sources/Category/CategoryInteractor.swift
@@ -17,17 +17,20 @@ protocol CategoryPresentable: Presentable {
 
 protocol CategoryListener: AnyObject {}
 
-final class CategoryInteractor: PresentableInteractor<CategoryPresentable>, CategoryInteractable, CategoryPresentableListener {
+final class CategoryInteractor: PresentableInteractor<CategoryPresentable>, CategoryInteractable {
 
     weak var router: CategoryRouting?
     weak var listener: CategoryListener?
     private let categoriesUseCase: CategoriesUseCase
+
+    private let categoriesSubject: BehaviorSubject<[Category]>
 
     init(
         presenter: CategoryPresentable,
         categoriesUseCase: CategoriesUseCase
     ) {
         self.categoriesUseCase = categoriesUseCase
+        categoriesSubject = .init(value: [])
 
         super.init(presenter: presenter)
         presenter.listener = self
@@ -35,9 +38,27 @@ final class CategoryInteractor: PresentableInteractor<CategoryPresentable>, Cate
 
     override func didBecomeActive() {
         super.didBecomeActive()
+
+        bindCategories()
     }
 
     override func willResignActive() {
         super.willResignActive()
+    }
+
+    func bindCategories() {
+        categoriesUseCase.execute()
+            .subscribe(onNext: {
+                self.categoriesSubject.onNext($0)
+            })
+            .disposeOnDeactivate(interactor: self)
+    }
+}
+
+extension CategoryInteractor: CategoryPresentableListener {
+    var categories: Observable<[Category]> { categoriesSubject }
+
+    func didTapCell(_ category: Category) {
+        // TODO: - 카테고리 셀 탭 이후 동작
     }
 }

--- a/Projects/Memo/Sources/Category/CategoryInteractor.swift
+++ b/Projects/Memo/Sources/Category/CategoryInteractor.swift
@@ -21,8 +21,14 @@ final class CategoryInteractor: PresentableInteractor<CategoryPresentable>, Cate
 
     weak var router: CategoryRouting?
     weak var listener: CategoryListener?
+    private let categoriesUseCase: CategoriesUseCase
 
-    override init(presenter: CategoryPresentable) {
+    init(
+        presenter: CategoryPresentable,
+        categoriesUseCase: CategoriesUseCase
+    ) {
+        self.categoriesUseCase = categoriesUseCase
+
         super.init(presenter: presenter)
         presenter.listener = self
     }

--- a/Projects/Memo/Sources/Entry/AppComponent.swift
+++ b/Projects/Memo/Sources/Entry/AppComponent.swift
@@ -9,8 +9,10 @@
 import RIBs
 
 class AppComponent: Component<EmptyDependency>, RootDependency {
+    var categoriesUseCase: CategoriesUseCase
 
-    init() {
-      super.init(dependency: EmptyComponent())
+    init(categoriesUseCase: CategoriesUseCase) {
+        self.categoriesUseCase = categoriesUseCase
+        super.init(dependency: EmptyComponent())
     }
 }

--- a/Projects/Memo/Sources/Entry/AppDelegate.swift
+++ b/Projects/Memo/Sources/Entry/AppDelegate.swift
@@ -19,7 +19,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
-        let launchRouter = RootBuilder(dependency: AppComponent()).build()
+        let launchRouter = RootBuilder(
+            dependency: AppComponent(
+                categoriesUseCase: DefaultCategoriesUseCase(categoryRepository: DefaultCategoryRepository())
+            )
+        ).build()
         self.launchRouter = launchRouter
         launchRouter.launch(from: window)
         return true

--- a/Projects/Memo/Sources/Repositories/CategoryRepository.swift
+++ b/Projects/Memo/Sources/Repositories/CategoryRepository.swift
@@ -1,0 +1,32 @@
+//
+//  CategoryRepository.swift
+//  Memo
+//
+//  Created by jaeyoung Yun on 2023/01/01.
+//  Copyright © 2023 Memo. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+protocol CategoryRepository {
+    var categories: Observable<[Category]> { get }
+}
+
+final class DefaultCategoryRepository: CategoryRepository {
+    // TODO: - 카테고리 개수를 체크하기 위해 저장해서 사용하기
+    private let _categories: [Category] = [
+        .init(icon: "book.closed", name: "독서", count: 22123),
+        .init(icon: "music.note.list", name: "음악", count: 4),
+        .init(icon: "note.text", name: "일상", count: 111),
+        .init(icon: "fork.knife", name: "음식", count: 71),
+        .init(icon: "airplane", name: "여행", count: 0),
+    ]
+
+    var categoriesSubject: BehaviorSubject<[Category]>
+    var categories: Observable<[Category]> { categoriesSubject }
+
+    init() {
+        categoriesSubject = .init(value: _categories)
+    }
+}

--- a/Projects/Memo/Sources/Root/RootBuilder.swift
+++ b/Projects/Memo/Sources/Root/RootBuilder.swift
@@ -7,7 +7,9 @@
 
 import RIBs
 
-protocol RootDependency: Dependency {}
+protocol RootDependency: Dependency {
+    var categoriesUseCase: CategoriesUseCase { get }
+}
 
 final class RootComponent: Component<RootDependency> {}
 

--- a/Projects/Memo/Sources/Root/RootComponent+Tab.swift
+++ b/Projects/Memo/Sources/Root/RootComponent+Tab.swift
@@ -9,5 +9,7 @@
 import RIBs
 
 extension RootComponent: TabDependency {
-    
+    var categoriesUseCase: CategoriesUseCase {
+        dependency.categoriesUseCase
+    }
 }

--- a/Projects/Memo/Sources/Tab/TabBuilder.swift
+++ b/Projects/Memo/Sources/Tab/TabBuilder.swift
@@ -8,7 +8,9 @@
 
 import RIBs
 
-protocol TabDependency: Dependency {}
+protocol TabDependency: Dependency {
+    var categoriesUseCase: CategoriesUseCase { get }
+}
 
 final class TabComponent: Component<TabDependency> {}
 

--- a/Projects/Memo/Sources/Tab/TabComponent+Category.swift
+++ b/Projects/Memo/Sources/Tab/TabComponent+Category.swift
@@ -8,4 +8,8 @@
 
 import RIBs
 
-extension TabComponent: CategoryDependency {}
+extension TabComponent: CategoryDependency {
+    var categoriesUseCase: CategoriesUseCase {
+        dependency.categoriesUseCase
+    }
+}

--- a/Projects/Memo/Sources/UseCases/CategoriesUseCase.swift
+++ b/Projects/Memo/Sources/UseCases/CategoriesUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  CategoriesUseCase.swift
+//  Memo
+//
+//  Created by jaeyoung Yun on 2023/01/01.
+//  Copyright © 2023 Memo. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+protocol CategoriesUseCase {
+    func execute() -> Observable<[Category]>
+}
+
+final class DefaultCategoriesUseCase: CategoriesUseCase {
+    private let categoryRepository: CategoryRepository
+
+    init(categoryRepository: CategoryRepository) {
+        self.categoryRepository = categoryRepository
+    }
+
+    func execute() -> Observable<[Category]> {
+        return categoryRepository.categories
+    }
+}

--- a/Projects/Memo/Sources/Utils/Array+safe.swift
+++ b/Projects/Memo/Sources/Utils/Array+safe.swift
@@ -1,0 +1,19 @@
+//
+//  Array+safe.swift
+//  Memo
+//
+//  Created by jaeyoung Yun on 2023/01/01.
+//  Copyright © 2023 Memo. All rights reserved.
+//
+
+import Foundation
+
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard indices ~= index else {
+            return nil
+        }
+
+        return self[index]
+    }
+}


### PR DESCRIPTION
UI와 껍데기만 있던 Category riblet에 
카테고리 리스트를 가져오는 CategoriesUseCase와 CategoryRepository를 추가했습니다.

카테고리 목록 자체는 정적으로 고정된 요소이기 때문에 하드코딩으로 데이터를 정의해놓으려고 했는데
생각해보니 카테고리안에 있는 글의 개수가 필요해서
추후에 CategoryRepository안에 카테고리 안에 있는 글의 개수를 가져오는 로직을 추가해야 합니다.

카테고리 자체를 DB에 저장해서 글 개수를 관리할 건지 글 DB에서 특정 카테고리에 속하는 글의 개수를 가져올 것인지는 고민해봐야 할 것 같습니다.