### PR TITLE
feat: CoreData Client 추가

### DIFF
--- a/Projects/Memo/Project.swift
+++ b/Projects/Memo/Project.swift
@@ -21,7 +21,8 @@ let appTarget = Target(
     infoPlist: .file(path: "Supported Files/Info.plist"),
     sources: "Sources/**",
     resources: "Resources/**",
-    dependencies: [RemoteDependencies.allPackages].flatMap { $0 }
+    dependencies: [RemoteDependencies.allPackages].flatMap { $0 },
+    coreDataModels: [CoreDataModel("Sources/CoreDataClient/Model.xcdatamodeld")]
 )
 
 let testTarget = Target(

--- a/Projects/Memo/Sources/CoreDataClient/ArticleEntity+CoreDataClass.swift
+++ b/Projects/Memo/Sources/CoreDataClient/ArticleEntity+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ArticleEntity+CoreDataClass.swift
+//  
+//
+//  Created by jaeyoung Yun on 2023/01/04.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ArticleEntity)
+public class ArticleEntity: NSManagedObject {
+
+}

--- a/Projects/Memo/Sources/CoreDataClient/ArticleEntity+CoreDataProperties.swift
+++ b/Projects/Memo/Sources/CoreDataClient/ArticleEntity+CoreDataProperties.swift
@@ -1,0 +1,26 @@
+//
+//  ArticleEntity+CoreDataProperties.swift
+//  
+//
+//  Created by jaeyoung Yun on 2023/01/04.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ArticleEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ArticleEntity> {
+        return NSFetchRequest<ArticleEntity>(entityName: "ArticleEntity")
+    }
+
+    @NSManaged public var id: UUID
+    @NSManaged public var content: String
+    @NSManaged public var source: String
+    @NSManaged public var page: String?
+    @NSManaged public var writer: String
+    @NSManaged public var createdAt: Date
+    @NSManaged public var categoryID: Int32
+}

--- a/Projects/Memo/Sources/CoreDataClient/CoreDataClient.swift
+++ b/Projects/Memo/Sources/CoreDataClient/CoreDataClient.swift
@@ -1,0 +1,165 @@
+//
+//  CoreDataClient.swift
+//  Memo
+//
+//  Created by jaeyoung Yun on 2023/01/03.
+//  Copyright © 2023 Memo. All rights reserved.
+//
+
+import CoreData
+import Foundation
+
+protocol CoreDataClientProtocol {
+
+    func insertArticleEntity(
+        id: UUID,
+        content: String,
+        source: String,
+        writer: String,
+        categoryID: Int32,
+        page: String?,
+        createdAt: Date
+    )
+    func fetchArticleEntity(offset: Int, limit: Int) -> [ArticleEntity]
+    func updateArticleEntity(
+        id: UUID,
+        content: String?,
+        source: String?,
+        writer: String?,
+        categoryID: Int32?,
+        page: String?
+    )
+    func deleteArticleEntity(_ id: UUID)
+}
+
+class CoreDataClient {
+    private let modelName: String
+
+    init(modelName: String) {
+        self.modelName = modelName
+    }
+
+    private lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: modelName)
+        container.loadPersistentStores { storeDescription, error in
+            if let error {
+                fatalError("PersistentStore loading error: \(error)")
+            }
+        }
+        return container
+    }()
+
+    private lazy var context: NSManagedObjectContext = persistentContainer.viewContext
+
+    private func saveContext() {
+        guard context.hasChanges else {
+            return
+        }
+        do {
+            try context.save()
+        } catch {
+            print("Failed to save context: \(error)")
+        }
+    }
+}
+
+extension CoreDataClient: CoreDataClientProtocol {
+
+    private var articleEntityEntity: NSEntityDescription? {
+        NSEntityDescription.entity(forEntityName: "ArticleEntity", in: context)
+    }
+
+    func insertArticleEntity(
+        id: UUID = .init(),
+        content: String,
+        source: String,
+        writer: String,
+        categoryID: Int32,
+        page: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        if let entity = articleEntityEntity {
+            let managedObject = NSManagedObject(entity: entity, insertInto: context)
+            managedObject.setValue(id, forKey: "id")
+            managedObject.setValue(content, forKey: "content")
+            managedObject.setValue(source, forKey: "source")
+            managedObject.setValue(writer, forKey: "writer")
+            managedObject.setValue(categoryID, forKey: "categoryID")
+            managedObject.setValue(page, forKey: "page")
+            managedObject.setValue(createdAt, forKey: "createdAt")
+            saveContext()
+        }
+    }
+
+    func fetchArticleEntity(offset: Int, limit: Int) -> [ArticleEntity] {
+        do {
+            let request = ArticleEntity.fetchRequest()
+            request.fetchOffset = offset
+            request.fetchLimit = limit
+            let results = try context.fetch(request)
+            return results
+        } catch {
+            print("Failed to fetch Articles: \(error)")
+        }
+
+        return []
+    }
+
+    func updateArticleEntity(
+        id: UUID,
+        content: String? = nil,
+        source: String? = nil,
+        writer: String? = nil,
+        categoryID: Int32? = nil,
+        page: String? = nil
+    ) {
+        guard let entity = getEntityByID(id) else {
+            return
+        }
+
+        if let content {
+            entity.content = content
+        }
+        if let source {
+            entity.source = source
+        }
+        if let writer {
+            entity.writer = writer
+        }
+        if let categoryID {
+            entity.categoryID = categoryID
+        }
+        if let page {
+            entity.page = page
+        }
+        saveContext()
+    }
+
+    func deleteArticleEntity(_ id: UUID) {
+        guard let entity = getEntityByID(id) else {
+            return
+        }
+
+        context.delete(entity)
+
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            print("Failed to delete Article: \(id), \(error)")
+        }
+    }
+
+    private func getEntityByID(_ id: UUID) -> ArticleEntity? {
+        do {
+            let request = ArticleEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id = %@", id.uuidString)
+            let result = try context.fetch(request)
+            return result.first
+        } catch {
+            print("Failed to find Article: \(id)")
+        }
+
+        return nil
+    }
+}

--- a/Projects/Memo/Sources/CoreDataClient/CoreDataClient.swift
+++ b/Projects/Memo/Sources/CoreDataClient/CoreDataClient.swift
@@ -58,7 +58,9 @@ class CoreDataClient {
         do {
             try context.save()
         } catch {
+            #if DEBUG
             print("Failed to save context: \(error)")
+            #endif
         }
     }
 }
@@ -99,7 +101,9 @@ extension CoreDataClient: CoreDataClientProtocol {
             let results = try context.fetch(request)
             return results
         } catch {
+            #if DEBUG
             print("Failed to fetch Articles: \(error)")
+            #endif
         }
 
         return []
@@ -146,7 +150,9 @@ extension CoreDataClient: CoreDataClientProtocol {
             try context.save()
         } catch {
             context.rollback()
+            #if DEBUG
             print("Failed to delete Article: \(id), \(error)")
+            #endif
         }
     }
 
@@ -157,7 +163,9 @@ extension CoreDataClient: CoreDataClientProtocol {
             let result = try context.fetch(request)
             return result.first
         } catch {
+            #if DEBUG
             print("Failed to find Article: \(id)")
+            #endif
         }
 
         return nil

--- a/Projects/Memo/Sources/CoreDataClient/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Projects/Memo/Sources/CoreDataClient/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22A380" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="ArticleEntity" representedClassName="ArticleEntity" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="content" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="page" optional="YES" attributeType="String"/>
+        <attribute name="source" attributeType="String"/>
+        <attribute name="writer" attributeType="String"/>
+    </entity>
+</model>


### PR DESCRIPTION
Article의 엔티티 버전인 ArticleEntity Coredata model을 정의했고

ArticleEntity에 대한 기본적인 CRUD 기능을 가진 CoreDataClient를 구현했습니다.

CoreDataClient의 CRUD 메서드에 Article 모델을 인자로 받을까 고민했지만
일단은 CoreDataClient에서는 Article 모델에 대해 모르게끔 구현을 했습니다.

카테고리 별 글들을 가져오는 기능은 아직 구현하지 않았습니다.